### PR TITLE
reduce release sizes and speed up release time

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -110,6 +110,16 @@ jobs:
           asset_path: go/out/dolt-windows-amd64.zip
           asset_name: dolt-windows-amd64.zip
           asset_content_type: application/zip
+      - name: Upload Windows Distro 7z
+        id: upload-windows-distro-7z
+        uses: dolthub/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: go/out/dolt-windows-amd64.7z
+          asset_name: dolt-windows-amd64.7z
+          asset_content_type: application/x-7z-compressed
       - name: Upload Install Script
         id: upload-install-script
         uses: dolthub/upload-release-asset@v1

--- a/go/utils/publishrelease/buildbinaries.sh
+++ b/go/utils/publishrelease/buildbinaries.sh
@@ -11,7 +11,7 @@ cd $script_dir/../..
 docker run --rm -v `pwd`:/src golang:"$GO_BUILD_VERSION"-buster /bin/bash -c '
 set -e
 set -o pipefail
-apt-get update && apt-get install -y zip
+apt-get update && apt-get install -y pzip pigz
 cd /src
 
 BINS="dolt"
@@ -29,12 +29,12 @@ for tuple in $OS_ARCH_TUPLES; do
     if [ "$os" = windows ]; then
       obin="$bin.exe"
     fi
-    CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -o "$o/bin/$obin" "./cmd/$bin/"
+    CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -ldflags="-s -w" -o "$o/bin/$obin" "./cmd/$bin/"
   done
   if [ "$os" = windows ]; then
-    (cd out && zip -r "dolt-$os-$arch" "dolt-$os-$arch")
+    (cd out && 7z a "dolt-$os-$arch.zip" "dolt-$os-$arch" && 7z a "dolt-$os-$arch.7z" "dolt-$os-$arch")
   else
-    tar czf "out/dolt-$os-$arch.tar.gz" -C out "dolt-$os-$arch"
+    tar cf - "dolt-$os-$arch" | pigz -9 > "out/dolt-$os-$arch.tar.gz"
   fi
 done
 


### PR DESCRIPTION
- Uses pigz instead of gzip for faster gzipping
- Uses 7zip to create zip and 7z archives for windows (7z archive is ~49% smaller than zip archive)
- add ldflags='-s' to go build to reduce binary size by strip (reduces to 89MB)